### PR TITLE
Add "host" as a configuration array item

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,10 @@ Please see the [Base Installation Guide](https://socialiteproviders.com/usage/),
 
 ```php
 'laravelpassport' => [    
-  'client_id' => env('LARAVELPASSPORT_CLIENT_ID'),  
+  'client_id' => env('LARAVELPASSPORT_CLIENT_ID'),
   'client_secret' => env('LARAVELPASSPORT_CLIENT_SECRET'),  
-  'redirect' => env('LARAVELPASSPORT_REDIRECT_URI') 
+  'redirect' => env('LARAVELPASSPORT_REDIRECT_URI'),
+  'host' => env('LARAVELPASSPORT_HOST'),
 ],
 ```
 


### PR DESCRIPTION
The `host` configuration item is necessary for this to work - it tells the SocialiteProvider where your passport host is. It should be included in base config.